### PR TITLE
fix(registry): align supported doc_type values between schema and implementation

### DIFF
--- a/skills/cuda-webdoc-search/references/registry_schema.md
+++ b/skills/cuda-webdoc-search/references/registry_schema.md
@@ -10,12 +10,10 @@ The file is a list of `[[library]]` tables.
 
 - `name` (string): Stable key used by CLI and code (e.g. `--source cccl`). Treat as immutable.
 - `doc_type` (string): Parser strategy. Allowed values:
-  - `sphinx` - Sphinx documentation with objects.inv
-  - `sphinx_noinv` - Sphinx documentation without objects.inv
-  - `doxygen` - Doxygen HTML with group__ pattern
-  - `mdbook` - mdBook documentation
-  - `pdf` - PDF documentation only (no web API docs)
-  - `custom` - Custom parser required
+  - `sphinx` - Sphinx documentation with objects.inv (symbol search supported)
+  - `doxygen` - Doxygen HTML with group__ pattern (symbol search supported)
+  - `sphinx_noinv` - Sphinx documentation without objects.inv (browse-only, no symbol search)
+  - `pdf` - PDF documentation only (browse-only, no symbol search)
 
 At least one of the following must be present (except for `pdf` type):
 - `inventory_urls` (array of string): Sphinx inventory endpoints (objects.inv).

--- a/skills/cuda-webdoc-search/topology_mapper.py
+++ b/skills/cuda-webdoc-search/topology_mapper.py
@@ -424,31 +424,37 @@ def main():
             group_urls = [g["url"] for g in top_groups]
             members = get_doxygen_members(group_urls, source_name=args.source)
             all_groups = top_groups + members
-        elif doc_type == "pdf":
-            doc_url = library.get("doc_url", "")
-            message = (
-                f"'{args.source}' is distributed as a PDF manual only. "
-                "Symbol search is not available. "
-                "Download the PDF to read the documentation."
-            )
+        elif doc_type in ("pdf", "sphinx_noinv"):
+            # Non-searchable sources: return guidance instead of candidates
+            doc_url = library.get("doc_url") or library.get("index_url", "")
+            if doc_type == "pdf":
+                label = "PDF manual"
+                message = (
+                    f"'{args.source}' is distributed as a PDF manual only. "
+                    "Symbol search is not available. "
+                    "Download the PDF to read the documentation."
+                )
+            else:
+                label = "docs (no inventory)"
+                message = (
+                    f"'{args.source}' has no Sphinx inventory for symbol search. "
+                    "Browse the documentation directly."
+                )
             if args.keywords:
-                # Keywords can't match a PDF-only source; return empty results
-                if args.list:
-                    pass
-                else:
+                if not args.list:
                     output = {
                         "source": effective_source,
                         "total_found": 0,
                         "filtered_count": 0,
                         "domains_filter": args.domains,
                         "candidates": [],
-                        "doc_type": "pdf",
+                        "doc_type": doc_type,
                         "doc_url": doc_url,
                         "message": message,
                     }
                     print(json.dumps(output, indent=2))
             elif args.list:
-                print(f"[PDF manual]\t{doc_url}")
+                print(f"[{label}]\t{doc_url}")
             else:
                 output = {
                     "source": effective_source,
@@ -456,7 +462,7 @@ def main():
                     "filtered_count": 0,
                     "domains_filter": args.domains,
                     "candidates": [],
-                    "doc_type": "pdf",
+                    "doc_type": doc_type,
                     "doc_url": doc_url,
                     "message": message,
                 }


### PR DESCRIPTION
## Summary
- Handle `sphinx_noinv` sources (cutensor) alongside `pdf` in a unified non-searchable path instead of erroring with "unsupported doc_type"
- Remove undeclared `mdbook` and `custom` doc_types from registry schema to match implementation
- Non-searchable sources return standard JSON schema (`candidates: []`) with guidance message

## Verification
| Source | Before | After |
|---|---|---|
| cutensor | `sys.exit(1)` "unsupported doc_type" | Guidance with doc URL |
| cutensor `--list` | crash | `[docs (no inventory)]\t<url>` |
| cutensor `--keywords` | crash | Empty results (correct) |
| amgx | No regression | No regression |

Closes #4