### PR TITLE
feat(audit): add registry audit command for endpoint health validation

### DIFF
--- a/skills/cuda-webdoc-search/registry_audit.py
+++ b/skills/cuda-webdoc-search/registry_audit.py
@@ -204,7 +204,7 @@ def audit_pdf(lib):
         if not ok:
             results["ok"] = False
     except Exception as e:
-        results["checks"].append({"check": "doc_url", "ok": False, "detail": str(e)})
+        results["checks"].append({"check": "doc_url", "ok": False, "detail": f"HEAD {doc_url} failed: {e}"})
         results["ok"] = False
 
     return results


### PR DESCRIPTION
## Summary
- Add `registry_audit.py` to validate all registry entries for endpoint liveness, inventory parseability, and search viability
- Supports per-source (`--source cutlass`) and full-registry audit modes
- JSON output to stdout for CI integration, human-readable table to stderr
- Exit code 1 on any failure for CI gating

## Checks per doc_type
| doc_type | Checks |
|---|---|
| sphinx | inventory URL liveness (with base_url fallback), inventory parse, domain counts |
| doxygen | index URL liveness, presence of group__ links |
| pdf | doc URL liveness, Content-Type validation (rejects HTML) |
| sphinx_noinv | index URL liveness |

## Verification
All 17 registry entries pass audit with exit code 0.

Closes #5