### PR TITLE
fix(registry): fail fast on registry load failure instead of silent fallback

### DIFF
--- a/skills/cuda-webdoc-search/topology_mapper.py
+++ b/skills/cuda-webdoc-search/topology_mapper.py
@@ -278,8 +278,10 @@ def load_registry(path):
             return tomllib.load(f)
     except FileNotFoundError:
         return f"registry not found: {path}"
-    except Exception as e:
+    except tomllib.TOMLDecodeError as e:
         return f"failed to parse registry {path}: {e}"
+    except Exception as e:
+        return f"failed to read registry {path}: {e}"
 
 
 def get_library_config(registry, name):


### PR DESCRIPTION
## Summary
- Fail fast with a clear error when registry cannot be loaded, instead of silently falling back to `cuda_runtime` results
- Fail fast when `--source` is not found in registry (unconditional check)
- Resolve default `registry.toml` path relative to script directory so it works from any working directory
- Remove dead fallback branches and hardcoded CCCL constants that are now in registry

## Test plan
- [ ] `--registry /nonexistent` → hard error with message
- [ ] `--source nonexistent_lib` → hard error with message
- [ ] `--source amgx` (pdf) → correct guidance output
- [ ] Run from repo root and /tmp → registry found via script dir

Closes #10