### PR TITLE
refactor(registry): extract shared load_registry into registry.py

### DIFF
--- a/skills/cuda-webdoc-search/registry.py
+++ b/skills/cuda-webdoc-search/registry.py
@@ -1,0 +1,24 @@
+"""Shared registry loading for cuda-webdoc-search scripts."""
+
+import os
+import tomllib
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_REGISTRY_PATH = os.path.join(_SCRIPT_DIR, "registry.toml")
+
+
+def load_registry(path):
+    """Load registry TOML file.
+
+    Returns:
+        Parsed registry dict on success, or a string error message on failure.
+    """
+    try:
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except FileNotFoundError:
+        return f"registry not found: {path}"
+    except tomllib.TOMLDecodeError as e:
+        return f"failed to parse registry {path}: {e}"
+    except Exception as e:
+        return f"failed to read registry {path}: {e}"

--- a/skills/cuda-webdoc-search/registry_audit.py
+++ b/skills/cuda-webdoc-search/registry_audit.py
@@ -12,26 +12,14 @@
 import argparse
 import json
 import sys
-import tomllib
 
 import requests
 import sphobjinv as soi
 from bs4 import BeautifulSoup
 
-DEFAULT_REGISTRY_PATH = "registry.toml"
+from registry import DEFAULT_REGISTRY_PATH, load_registry
+
 REQUEST_TIMEOUT = 15
-
-
-def load_registry(path):
-    try:
-        with open(path, "rb") as f:
-            return tomllib.load(f)
-    except FileNotFoundError:
-        print(f"Error: registry file not found: {path}", file=sys.stderr)
-        sys.exit(1)
-    except tomllib.TOMLDecodeError as e:
-        print(f"Error: failed to parse registry file {path}: {e}", file=sys.stderr)
-        sys.exit(1)
 
 
 def check_url(url, timeout=REQUEST_TIMEOUT):
@@ -298,6 +286,9 @@ def main():
     args = parser.parse_args()
 
     registry = load_registry(args.registry)
+    if isinstance(registry, str):
+        print(f"Error: {registry}", file=sys.stderr)
+        sys.exit(1)
     libraries = registry.get("library", [])
 
     if args.source:

--- a/skills/cuda-webdoc-search/topology_mapper.py
+++ b/skills/cuda-webdoc-search/topology_mapper.py
@@ -15,16 +15,15 @@ import json
 import sys
 import argparse
 import os
-import tomllib
 from urllib.parse import urljoin
 from rapidfuzz import process, fuzz
 
 import sphobjinv as soi
 
+from registry import DEFAULT_REGISTRY_PATH, load_registry
+
 BASE_URL = "https://docs.nvidia.com/cuda/cuda-runtime-api/"
 MODULES_URL = urljoin(BASE_URL, "modules.html")
-_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-DEFAULT_REGISTRY_PATH = os.path.join(_SCRIPT_DIR, "registry.toml")
 
 
 def probe_inventory_url(url, timeout=10):
@@ -266,22 +265,6 @@ def filter_groups(groups, keywords, use_fuzzy=False, threshold=60.0):
 
     return filtered
 
-
-def load_registry(path):
-    """Load registry TOML file.
-
-    Returns:
-        Parsed registry dict on success, or a string error message on failure.
-    """
-    try:
-        with open(path, "rb") as f:
-            return tomllib.load(f)
-    except FileNotFoundError:
-        return f"registry not found: {path}"
-    except tomllib.TOMLDecodeError as e:
-        return f"failed to parse registry {path}: {e}"
-    except Exception as e:
-        return f"failed to read registry {path}: {e}"
 
 
 def get_library_config(registry, name):


### PR DESCRIPTION
## Summary
- Extract duplicated `load_registry` and `DEFAULT_REGISTRY_PATH` into shared `registry.py` module
- Both `topology_mapper.py` and `registry_audit.py` now import from `registry.py`
- Fixes `registry_audit.py` missing the #15 improvements (error-string return, `__file__`-relative path, `TOMLDecodeError` separation)

## Test plan
- [ ] `topology_mapper.py --registry /nonexistent` → `registry not found`
- [ ] `registry_audit.py --registry /nonexistent` → `registry not found`
- [ ] Both scripts work from non-skill directories (path resolved via `__file__`)