### PR TITLE
test: add tests for structure_extractor and registry_audit

### DIFF
--- a/skills/cuda-webdoc-search/tests/test_registry_audit.py
+++ b/skills/cuda-webdoc-search/tests/test_registry_audit.py
@@ -1,0 +1,110 @@
+"""Tests for registry_audit.py — audit dispatch and validation logic."""
+
+import pytest
+
+from registry_audit import audit_library, print_table
+
+
+# -- audit_library dispatch --------------------------------------------------
+
+class TestAuditLibrary:
+    def test_unsupported_doc_type(self):
+        lib = {"name": "testlib", "doc_type": "unknown_type"}
+        result = audit_library(lib)
+        assert result["ok"] is False
+        assert result["name"] == "testlib"
+        assert result["doc_type"] == "unknown_type"
+        assert any("unsupported" in c["detail"] for c in result["checks"])
+
+    def test_missing_name(self):
+        lib = {"doc_type": "unknown_type"}
+        result = audit_library(lib)
+        assert result["name"] == "unknown"
+
+    def test_missing_doc_type(self):
+        lib = {"name": "testlib"}
+        result = audit_library(lib)
+        assert result["doc_type"] == "unknown"
+        assert result["ok"] is False
+
+
+# -- audit_* input validation (no network) -----------------------------------
+
+class TestAuditInputValidation:
+    def test_sphinx_no_urls(self):
+        """sphinx with no inventory_urls or base_urls should fail."""
+        from registry_audit import audit_sphinx
+        lib = {}
+        result = audit_sphinx(lib)
+        assert result["ok"] is False
+        assert any("no inventory_urls" in c["detail"] for c in result["checks"])
+
+    def test_doxygen_no_index_url(self):
+        """doxygen with no index_url should fail."""
+        from registry_audit import audit_doxygen
+        lib = {}
+        result = audit_doxygen(lib)
+        assert result["ok"] is False
+        assert any("no index_url" in c["detail"] for c in result["checks"])
+
+    def test_pdf_no_doc_url(self):
+        """pdf with no doc_url should fail."""
+        from registry_audit import audit_pdf
+        lib = {}
+        result = audit_pdf(lib)
+        assert result["ok"] is False
+        assert any("no doc_url" in c["detail"] for c in result["checks"])
+
+    def test_sphinx_noinv_no_index_url(self):
+        """sphinx_noinv with no index_url should fail."""
+        from registry_audit import audit_sphinx_noinv
+        lib = {}
+        result = audit_sphinx_noinv(lib)
+        assert result["ok"] is False
+        assert any("no index_url" in c["detail"] for c in result["checks"])
+
+
+# -- print_table formatting --------------------------------------------------
+
+class TestPrintTable:
+    def test_ok_result(self, capsys):
+        results = [{
+            "name": "cublas",
+            "doc_type": "sphinx",
+            "ok": True,
+            "checks": [
+                {"check": "inventory_url", "ok": True, "detail": "https://example.com/objects.inv"},
+            ],
+        }]
+        print_table(results)
+        captured = capsys.readouterr()
+        assert "cublas" in captured.err
+        assert "OK" in captured.err
+
+    def test_fail_result(self, capsys):
+        results = [{
+            "name": "badlib",
+            "doc_type": "sphinx",
+            "ok": False,
+            "checks": [
+                {"check": "inventory_url", "ok": False, "detail": "404 not found"},
+            ],
+        }]
+        print_table(results)
+        captured = capsys.readouterr()
+        assert "badlib" in captured.err
+        assert "FAIL" in captured.err
+        assert "404" in captured.err
+
+    def test_truncates_long_detail(self, capsys):
+        results = [{
+            "name": "lib",
+            "doc_type": "sphinx",
+            "ok": True,
+            "checks": [
+                {"check": "x", "ok": True, "detail": "a" * 100},
+            ],
+        }]
+        print_table(results)
+        captured = capsys.readouterr()
+        assert "..." in captured.err

--- a/skills/cuda-webdoc-search/tests/test_structure_extractor.py
+++ b/skills/cuda-webdoc-search/tests/test_structure_extractor.py
@@ -1,0 +1,161 @@
+"""Tests for structure_extractor.py — HTML parsing and tree conversion."""
+
+import pytest
+from bs4 import BeautifulSoup
+
+from structure_extractor import (
+    clean_soup,
+    extract_section,
+    format_output,
+    html_to_brace_tree,
+    is_noise,
+)
+
+
+def _soup(html):
+    return BeautifulSoup(html, "html.parser")
+
+
+# -- is_noise ----------------------------------------------------------------
+
+class TestIsNoise:
+    @pytest.mark.parametrize("text", [None, "", "   ", "\t"])
+    def test_empty_or_whitespace(self, text):
+        assert is_noise(text) is True
+
+    @pytest.mark.parametrize("text", ["#", ",", ".", "(", ")", "[", "]", ";", ":", "*", "&", "–", "-"])
+    def test_single_punctuation(self, text):
+        assert is_noise(text) is True
+
+    @pytest.mark.parametrize("text", ["hello", "cudaMemcpy", "int x", "a"])
+    def test_real_content(self, text):
+        assert is_noise(text) is False
+
+
+# -- format_output -----------------------------------------------------------
+
+class TestFormatOutput:
+    def test_collapses_spaces(self):
+        assert format_output("hello   world") == "hello world"
+
+    def test_collapses_tabs(self):
+        assert format_output("hello\t\tworld") == "hello world"
+
+    def test_strips_lines(self):
+        assert format_output("  hello  \n  world  ") == "hello\nworld"
+
+    def test_removes_blank_lines(self):
+        assert format_output("hello\n\n\nworld") == "hello\nworld"
+
+    def test_empty_input(self):
+        assert format_output("") == ""
+
+
+# -- html_to_brace_tree ------------------------------------------------------
+
+class TestHtmlToBraceTree:
+    def test_plain_text(self):
+        result = html_to_brace_tree(_soup("<p>Hello world</p>"))
+        assert "Hello world" in result
+
+    def test_skips_script(self):
+        result = html_to_brace_tree(_soup("<div><script>var x=1;</script><p>content</p></div>"))
+        assert "var x" not in result
+        assert "content" in result
+
+    def test_skips_style(self):
+        result = html_to_brace_tree(_soup("<div><style>.x{}</style><p>content</p></div>"))
+        assert ".x{}" not in result
+        assert "content" in result
+
+    def test_skips_nav_footer_header(self):
+        html = "<div><nav>nav text</nav><footer>foot</footer><header>head</header><p>content</p></div>"
+        result = html_to_brace_tree(_soup(html))
+        assert "nav text" not in result
+        assert "foot" not in result
+        assert "head" not in result
+        assert "content" in result
+
+    def test_inline_elements(self):
+        result = html_to_brace_tree(_soup("<p><code>cudaMalloc</code></p>"))
+        assert "cudaMalloc" in result
+
+    def test_nested_structure(self):
+        html = "<div><h2>Title</h2><p>Body text</p></div>"
+        result = html_to_brace_tree(_soup(html))
+        assert "Title" in result
+        assert "Body text" in result
+
+    def test_noise_filtered(self):
+        html = "<div><span>#</span><p>real content</p></div>"
+        result = html_to_brace_tree(_soup(html))
+        assert "real content" in result
+
+    def test_empty_element(self):
+        result = html_to_brace_tree(_soup("<div></div>"))
+        assert result == ""
+
+    def test_brace_wrapping_for_children(self):
+        html = "<div><p>first</p><p>second</p></div>"
+        result = html_to_brace_tree(_soup(html))
+        assert "{" in result
+        assert "first" in result
+        assert "second" in result
+
+
+# -- extract_section ---------------------------------------------------------
+
+class TestExtractSection:
+    def test_by_id(self):
+        html = '<div><section id="api-ref"><h2>API Reference</h2><p>Details</p></section></div>'
+        soup = _soup(html)
+        section = extract_section(soup, "api-ref")
+        assert section is not None
+        assert "Details" in section.get_text()
+
+    def test_by_heading_text(self):
+        html = "<div><section><h2>Memory Management</h2><p>Details</p></section></div>"
+        soup = _soup(html)
+        section = extract_section(soup, "memory management")
+        assert section is not None
+        assert "Details" in section.get_text()
+
+    def test_heading_case_insensitive(self):
+        html = "<div><section><h3>CUDA Runtime</h3><p>Info</p></section></div>"
+        soup = _soup(html)
+        assert extract_section(soup, "cuda runtime") is not None
+
+    def test_not_found(self):
+        html = "<div><p>Nothing here</p></div>"
+        soup = _soup(html)
+        assert extract_section(soup, "nonexistent") is None
+
+
+# -- clean_soup --------------------------------------------------------------
+
+class TestCleanSoup:
+    def test_removes_script_and_style(self):
+        html = "<div><script>x</script><style>.y{}</style><p>content</p></div>"
+        soup = clean_soup(_soup(html))
+        assert soup.find("script") is None
+        assert soup.find("style") is None
+        assert "content" in soup.get_text()
+
+    def test_removes_nav_footer_header(self):
+        html = "<div><nav>n</nav><footer>f</footer><header>h</header><p>ok</p></div>"
+        soup = clean_soup(_soup(html))
+        assert soup.find("nav") is None
+        assert soup.find("footer") is None
+        assert soup.find("header") is None
+
+    def test_removes_hidden_elements(self):
+        html = '<div><p style="display:none">hidden</p><p>visible</p></div>'
+        soup = clean_soup(_soup(html))
+        text = soup.get_text()
+        assert "hidden" not in text
+        assert "visible" in text
+
+    def test_preserves_content(self):
+        html = "<div><p>keep this</p></div>"
+        soup = clean_soup(_soup(html))
+        assert "keep this" in soup.get_text()


### PR DESCRIPTION
## Summary
- Add test suite for `structure_extractor.py`: `is_noise`, `format_output`, `html_to_brace_tree`, `extract_section`, `clean_soup`
- Add test suite for `registry_audit.py`: `audit_library` dispatch, input validation for all auditor types, `print_table` formatting
- Total coverage: 37% -> 66% (87 tests, all pass)

## Coverage
| Module | Before | After |
|--------|--------|-------|
| `registry.py` | 100% | 100% |
| `registry_audit.py` | 0% | 37% |
| `structure_extractor.py` | 0% | 65% |
| `topology_mapper.py` | 40% | 40% |

## Test plan
- [x] 87 tests pass
- [x] No network dependencies in new tests
- [x] structure_extractor tests use BeautifulSoup with HTML literals
- [x] registry_audit tests exercise validation paths without HTTP