### PR TITLE
fix: make fuzzy matching case-insensitive

### DIFF
--- a/skills/cuda-webdoc-search/tests/test_topology_mapper.py
+++ b/skills/cuda-webdoc-search/tests/test_topology_mapper.py
@@ -168,7 +168,7 @@ class TestFilterGroupsFuzzy:
         assert all("matched_keyword" in g for g in result)
 
     def test_fuzzy_case_insensitive(self):
-        """Uppercase keywords match lowercase group names."""
+        """Uppercase keywords match mixed-case group names case-insensitively."""
         result = filter_groups(
             SAMPLE_GROUPS, ["MEMCPY"], use_fuzzy=True, threshold=60.0
         )

--- a/skills/cuda-webdoc-search/topology_mapper.py
+++ b/skills/cuda-webdoc-search/topology_mapper.py
@@ -314,15 +314,14 @@ def filter_groups(groups, keywords, use_fuzzy=False, threshold=60.0):
 
     filtered = []
 
-    # Pre-process group names for fuzzy matching (lowercase for case-insensitive)
-    group_names_lower = [g["group"].lower() for g in groups]
-
     # Track best matches by group to avoid duplicates but keep highest score
     best_matches = {}
+    group_names_lower = None
 
     for kw in keywords:
         if use_fuzzy:
-            # Use RapidFuzz with lowercased names for case-insensitive matching
+            if group_names_lower is None:
+                group_names_lower = [g["group"].lower() for g in groups]
             results = process.extract(
                 kw.lower(), group_names_lower, scorer=fuzz.partial_ratio, limit=None
             )


### PR DESCRIPTION
## Summary
- Lowercase both keywords and group names before fuzzy scoring
- Previously `--keywords SVD --fuzzy` returned 0 results against lowercase inventory names like `gesvd`

Found during manual UX testing of cross-library search workflows.