### PR TITLE
feat(cli): add cws list subcommand

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "CUDA-X library documentation search and development skills",
-    "version": "2026.4.1"
+    "version": "2026.4.2"
   },
   "plugins": [
     {

--- a/skills/cuda-webdoc-search/README.md
+++ b/skills/cuda-webdoc-search/README.md
@@ -37,8 +37,9 @@ uvx --from "cuda-webdoc-search @ git+https://github.com/ultimatile/cuda-x-skills
 | Command | Description |
 |---------|-------------|
 | `cws search` | Search API symbols across CUDA-X library documentation |
-| `cws audit` | Audit registry entries for endpoint health |
 | `cws get` | Extract documentation content as brace-delimited text tree |
+| `cws list` | List available documentation sources from the registry |
+| `cws audit` | Audit registry entries for endpoint health |
 
 Run `cws <command> --help` for full option details.
 
@@ -57,6 +58,9 @@ cws search cusolver cudss --keywords "svd" --fuzzy --limit 10
 # Extract documentation for a specific function
 cws get "https://docs.nvidia.com/cuda/cuquantum/latest/cutensornet/api/functions.html" \
   --section "cutensornetTensorSVD"
+
+# List available sources
+cws list
 
 # Audit all registry entries
 cws audit

--- a/skills/cuda-webdoc-search/SKILL.md
+++ b/skills/cuda-webdoc-search/SKILL.md
@@ -144,6 +144,13 @@ Parameters { ... }
 }
 ```
 
+### List available sources
+
+```bash
+cws list                     # table format
+cws list --json              # JSON format
+```
+
 ### Audit registry health
 
 ```bash

--- a/skills/cuda-webdoc-search/cli.py
+++ b/skills/cuda-webdoc-search/cli.py
@@ -1,10 +1,13 @@
 """CUDA-X Documentation Search Tools — unified CLI entry point."""
 
+import json as json_mod
+import sys
 from importlib.metadata import version
 from typing import Annotated, Optional
 
 import typer
 
+import registry
 from audit import audit
 from get import get_doc
 from search import search
@@ -38,6 +41,48 @@ def main(
 app.command("search")(search)
 app.command("audit")(audit)
 app.command("get")(get_doc)
+
+
+@app.command("list")
+def list_sources(
+    json: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    registry_path: Annotated[
+        str,
+        typer.Option("--registry", help="Registry TOML path"),
+    ] = registry.DEFAULT_REGISTRY_PATH,
+):
+    """List available documentation sources from the registry."""
+    reg = registry.load_registry(registry_path)
+    if isinstance(reg, str):
+        print(f"Error: {reg}", file=sys.stderr)
+        raise typer.Exit(1)
+
+    libraries = reg.get("library", [])
+
+    if json:
+        entries = [
+            {
+                "name": lib.get("name", ""),
+                "doc_type": lib.get("doc_type", ""),
+                "description": lib.get("description", ""),
+                "tags": lib.get("tags", []),
+            }
+            for lib in libraries
+        ]
+        print(json_mod.dumps(entries, indent=2))
+    else:
+        print(f"{'name':<20} {'doc_type':<14} {'description'}")
+        print("-" * 72)
+        for lib in libraries:
+            name = lib.get("name", "")
+            doc_type = lib.get("doc_type", "")
+            desc = lib.get("description", "")
+            tags = lib.get("tags", [])
+            if tags:
+                desc += f" [{', '.join(tags)}]"
+            if len(desc) > 40:
+                desc = desc[:37] + "..."
+            print(f"{name:<20} {doc_type:<14} {desc}")
 
 
 if __name__ == "__main__":

--- a/skills/cuda-webdoc-search/cli.py
+++ b/skills/cuda-webdoc-search/cli.py
@@ -71,8 +71,13 @@ def list_sources(
         ]
         print(json_mod.dumps(entries, indent=2))
     else:
+        import shutil
+
+        cols = shutil.get_terminal_size((120, 24)).columns
+        prefix_width = 20 + 14  # name + doc_type columns
+        desc_width = max(cols - prefix_width, 20)
         print(f"{'name':<20} {'doc_type':<14} {'description'}")
-        print("-" * 72)
+        print("-" * min(cols, 120))
         for lib in libraries:
             name = lib.get("name", "")
             doc_type = lib.get("doc_type", "")
@@ -80,8 +85,8 @@ def list_sources(
             tags = lib.get("tags", [])
             if tags:
                 desc += f" [{', '.join(tags)}]"
-            if len(desc) > 40:
-                desc = desc[:37] + "..."
+            if len(desc) > desc_width:
+                desc = desc[: desc_width - 3] + "..."
             print(f"{name:<20} {doc_type:<14} {desc}")
 
 

--- a/skills/cuda-webdoc-search/pyproject.toml
+++ b/skills/cuda-webdoc-search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cuda-webdoc-search"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.11"
 dependencies = ["beautifulsoup4", "rapidfuzz", "requests", "sphobjinv", "typer"]
 

--- a/skills/cuda-webdoc-search/tests/test_structure_extractor.py
+++ b/skills/cuda-webdoc-search/tests/test_structure_extractor.py
@@ -1,8 +1,11 @@
-"""Tests for get.py — HTML parsing and tree conversion."""
+"""Tests for get.py — HTML parsing, tree conversion, and CLI integration."""
 
 import pytest
 from bs4 import BeautifulSoup
+from typer.testing import CliRunner
 
+import registry
+from cli import app
 from get import (
     clean_soup,
     extract_section,
@@ -10,6 +13,8 @@ from get import (
     html_to_brace_tree,
     is_noise,
 )
+
+_runner = CliRunner()
 
 
 def _soup(html):
@@ -170,3 +175,56 @@ class TestCleanSoup:
         html = "<div><p>keep this</p></div>"
         soup = clean_soup(_soup(html))
         assert "keep this" in soup.get_text()
+
+
+# -- cws list CLI integration ------------------------------------------------
+
+_LIST_REGISTRY = {
+    "library": [
+        {
+            "name": "cublas",
+            "doc_type": "sphinx",
+            "description": "GPU-accelerated BLAS",
+            "tags": ["cuBLAS"],
+        },
+        {
+            "name": "cuda_runtime",
+            "doc_type": "doxygen",
+            "description": "CUDA Runtime API",
+        },
+    ]
+}
+
+
+class TestListSourcesCli:
+    @pytest.fixture(autouse=True)
+    def mock_registry(self, monkeypatch):
+        monkeypatch.setattr(registry, "load_registry", lambda _: _LIST_REGISTRY)
+
+    def test_table_output(self):
+        result = _runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "cublas" in result.stdout
+        assert "cuda_runtime" in result.stdout
+
+    def test_json_output(self):
+        import json
+
+        result = _runner.invoke(app, ["list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        names = {e["name"] for e in data}
+        assert "cublas" in names
+        assert "cuda_runtime" in names
+
+    def test_json_has_all_fields(self):
+        import json
+
+        result = _runner.invoke(app, ["list", "--json"])
+        data = json.loads(result.stdout)
+        for entry in data:
+            assert "name" in entry
+            assert "doc_type" in entry
+            assert "description" in entry
+            assert "tags" in entry

--- a/skills/cuda-webdoc-search/tests/test_structure_extractor.py
+++ b/skills/cuda-webdoc-search/tests/test_structure_extractor.py
@@ -222,6 +222,7 @@ class TestListSourcesCli:
         import json
 
         result = _runner.invoke(app, ["list", "--json"])
+        assert result.exit_code == 0
         data = json.loads(result.stdout)
         for entry in data:
             assert "name" in entry


### PR DESCRIPTION
## Summary

- Add `cws list` subcommand to show available documentation sources from the registry
- Table format (default) and `--json` for machine-readable output
- 3 new tests via CliRunner